### PR TITLE
Quality "%" in red color, if the threshold is not crossed instead of yellow

### DIFF
--- a/lib/ui/process_ui/widgets_mobile/biometric_capture_control_portrait.dart
+++ b/lib/ui/process_ui/widgets_mobile/biometric_capture_control_portrait.dart
@@ -144,7 +144,7 @@ class _BiometricCaptureControlPortraitState
                                       .toInt() <
                                   int.parse(biometricAttributeData
                                       .thresholdPercentage))
-                              ? secondaryColors.elementAt(26)
+                              ? secondaryColors.elementAt(16)
                               : secondaryColors.elementAt(11),
                           borderRadius: BorderRadius.circular(50)),
                       height: 40,


### PR DESCRIPTION
[RCF-824]

[RCF-824]: https://mosip.atlassian.net/browse/RCF-824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ