### PR TITLE
RCF-1256  In the auto logged out, while in the offline mode the warning pop up time start after 5 minutes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -114,6 +114,9 @@ class _BuildAppState extends State<BuildApp> {
   void initState() {
     super.initState();
     _loadIdleTimeFromServer();
+    final connectivity = Provider.of<ConnectivityProvider>(context, listen: false);
+    connectivity.startAutoNetworkCheck();
+
   }
 
   Future<void> _loadIdleTimeFromServer() async {

--- a/lib/provider/connectivity_provider.dart
+++ b/lib/provider/connectivity_provider.dart
@@ -5,6 +5,8 @@
  *
 */
 
+import 'dart:async';
+
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
@@ -19,6 +21,22 @@ class ConnectivityProvider extends ChangeNotifier {
   ConnectivityResult get connectivityResult => _connectivityResult;
   bool get isConnected => _isConnected;
   bool get isGPSEnabled => _isGPSEnabled;
+
+  Timer? _autoCheckTimer;
+
+  void startAutoNetworkCheck() {
+    _autoCheckTimer?.cancel();
+
+    _autoCheckTimer = Timer.periodic(const Duration(seconds: 3), (timer) {
+      checkNetworkConnection();
+    });
+  }
+
+  @override
+  void dispose() {
+    _autoCheckTimer?.cancel();
+    super.dispose();
+  }
 
   checkNetworkConnection() async {
     String response = await networkService.checkInternetConnection();

--- a/lib/utils/inactivity_tracker.dart
+++ b/lib/utils/inactivity_tracker.dart
@@ -45,7 +45,6 @@ class _InactivityTrackerState extends State<InactivityTracker> with WidgetsBindi
 
     final connectivity = Provider.of<ConnectivityProvider>(context, listen: false);
 
-    // 🔥 When network status changes, offline should trigger popup
     connectivity.addListener(() {
       if (!connectivity.isConnected) {
         Future.microtask(() {

--- a/lib/utils/inactivity_tracker.dart
+++ b/lib/utils/inactivity_tracker.dart
@@ -6,6 +6,7 @@ import 'package:registration_client/provider/global_provider.dart';
 import 'package:registration_client/provider/sync_provider.dart';
 
 import '../main.dart';
+import '../provider/connectivity_provider.dart';
 
 class InactivityTracker extends StatefulWidget {
   final Widget child;
@@ -41,6 +42,18 @@ class _InactivityTrackerState extends State<InactivityTracker> with WidgetsBindi
     super.initState();
     globalProvider = Provider.of<GlobalProvider>(context, listen: false);
     WidgetsBinding.instance.addObserver(this);
+
+    final connectivity = Provider.of<ConnectivityProvider>(context, listen: false);
+
+    // 🔥 When network status changes, offline should trigger popup
+    connectivity.addListener(() {
+      if (!connectivity.isConnected) {
+        Future.microtask(() {
+          if (mounted) _showWarningDialog();
+        });
+      }
+    });
+
     _startInactivityTimer();
   }
 
@@ -63,7 +76,22 @@ class _InactivityTrackerState extends State<InactivityTracker> with WidgetsBindi
   }
 
   void _startInactivityTimer() {
+    final connectivity = Provider.of<ConnectivityProvider>(context, listen: false);
+    if (!connectivity.isConnected) {
+      Future.microtask(() {
+        if (mounted) _showWarningDialog();
+      });
+      return;
+    }
+
     if (!widget.isUserLoggedIn) return;
+
+    if (!connectivity.isConnected) {
+      Future.microtask(() {
+        if (mounted) _showWarningDialog();
+      });
+      return;
+    }
     _inactivityTimer = Timer(widget.timeout, _showWarningDialog);
   }
 


### PR DESCRIPTION
[RCF-1256]

[RCF-1256]: https://mosip.atlassian.net/browse/RCF-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic network connectivity monitoring now starts during app launch
  * Periodic network status checks keep the app updated about online/offline state

* **Bug Fixes**
  * Inactivity tracking no longer starts while offline
  * Shows a warning when connectivity is lost during inactivity tracking and cleans up background checks on shutdown
<!-- end of auto-generated comment: release notes by coderabbit.ai -->