### PR TITLE
RCF -1371 : handle the allow once and don't allow behavior. 

### DIFF
--- a/lib/provider/global_provider.dart
+++ b/lib/provider/global_provider.dart
@@ -939,7 +939,7 @@ class GlobalProvider with ChangeNotifier {
     bool hasPermission =
         await LocationService.instance.checkLocationPermissionForSession();
     await audit.performAudit(
-      "REG-NAV-005",
+      "NAV_GEO_LOCATION",
       "REG-MOD-102",
     );
     if (!hasPermission) {

--- a/lib/provider/global_provider.dart
+++ b/lib/provider/global_provider.dart
@@ -25,6 +25,7 @@ import 'package:registration_client/platform_spi/network_service.dart';
 import 'package:registration_client/platform_spi/packet_service.dart';
 import 'package:registration_client/platform_spi/process_spec_service.dart';
 import 'package:registration_client/utils/constants.dart';
+import 'package:registration_client/utils/location_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class GlobalProvider with ChangeNotifier {
@@ -917,9 +918,9 @@ class GlobalProvider with ChangeNotifier {
     // Check if GPS is enabled in configuration
     String gpsFlag = await globalConfigService.getGpsEnableFlag();
 
-    if (gpsFlag.isEmpty || gpsFlag != "Y") {
-      return null;
-    }
+    // if (gpsFlag.isEmpty || gpsFlag != "Y") {
+    //   return null;
+    // }
 
     // Check if location service is enabled on device
     bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
@@ -927,17 +928,10 @@ class GlobalProvider with ChangeNotifier {
       return null;
     }
 
-    // Check and request permission
-    LocationPermission permission = await Geolocator.checkPermission();
-    if (permission == LocationPermission.denied) {
-      permission = await Geolocator.requestPermission();
-      if (permission == LocationPermission.denied) {
-        // Permissions still denied
-        return null;
-      }
-    }
-
-    if (permission == LocationPermission.deniedForever) {
+    // Session-aware permission: re-request if user had chosen "Only this time" in a previous session
+    bool hasPermission =
+        await LocationService.instance.checkLocationPermissionForSession();
+    if (!hasPermission) {
       return null;
     }
 

--- a/lib/provider/global_provider.dart
+++ b/lib/provider/global_provider.dart
@@ -938,7 +938,7 @@ class GlobalProvider with ChangeNotifier {
     // Session-aware permission: re-request if user had chosen "Only this time" in a previous session
     bool hasPermission =
         await LocationService.instance.checkLocationPermissionForSession();
-    audit.performAudit(
+    await audit.performAudit(
       "REG-NAV-005",
       "REG-MOD-102",
     );

--- a/lib/ui/login_page.dart
+++ b/lib/ui/login_page.dart
@@ -36,6 +36,7 @@ import 'package:colorful_progress_indicators/colorful_progress_indicators.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../utils/life_cycle_event_handler.dart';
+import '../utils/location_service.dart';
 
 class LoginPage extends StatefulWidget {
   static const route = "/login-page";
@@ -342,7 +343,7 @@ class _LoginPageState extends State<LoginPage> with WidgetsBindingObserver {
       await _autoSyncHandler();
     } else {
       authProvider.setIsSyncing(false);
-      _navigateToHomePage();
+      await _navigateToHomePage();
     }
     setState(() {
       isLoggingIn = false;
@@ -362,8 +363,12 @@ class _LoginPageState extends State<LoginPage> with WidgetsBindingObserver {
     _showInSnackBar(snackbarText);
   }
 
-  _navigateToHomePage() {
+  _navigateToHomePage() async {
     if (authProvider.isLoggedIn == true) {
+      // Start new location session so permission is re-requested if user chose "Only this time" previously
+      await LocationService.instance.startNewSession();
+
+      if (!context.mounted) return;
       Navigator.popUntil(context, ModalRoute.withName('/login-page'));
 
       if (authProvider.isOnboarded || authProvider.isDefault) {
@@ -372,6 +377,7 @@ class _LoginPageState extends State<LoginPage> with WidgetsBindingObserver {
         globalProvider.setCurrentIndex(0);
       }
 
+      if (!context.mounted) return;
       Navigator.of(context).push(
         MaterialPageRoute(
           builder: (context) => Responsive(

--- a/lib/ui/onboard/home_page.dart
+++ b/lib/ui/onboard/home_page.dart
@@ -64,6 +64,9 @@ class _HomePageState extends State<HomePage> {
         Provider.of<ConnectivityProvider>(context, listen: false);
     _fetchProcessSpec();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
+      // Check GPS status to update the indicator in profile
+      await connectivityProvider.checkGPSStatus();
+      // Fetch location if GPS is enabled
       await globalProvider.fetchLocation();
     });
     super.initState();

--- a/lib/ui/profile/logout_alert.dart
+++ b/lib/ui/profile/logout_alert.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import '../../provider/auth_provider.dart';
 import '../../provider/global_provider.dart';
 import '../../utils/app_config.dart';
+import '../../utils/location_service.dart';
 
 class LogoutAlert extends StatefulWidget {
   const LogoutAlert({super.key});
@@ -125,6 +126,8 @@ class _LogoutAlertState extends State<LogoutAlert> {
                     shape: const RoundedRectangleBorder(
                         borderRadius: BorderRadius.all(Radius.circular(5.0)))),
                 onPressed: () async {
+                  // End location session so permission will be re-requested on next login
+                  await LocationService.instance.endSession();
                   String result = await authProvider.logoutUser();
                   if (result.contains("Logout Success")) {
                     _showInSnackBar(appLocalizations.logout_success);

--- a/lib/utils/location_service.dart
+++ b/lib/utils/location_service.dart
@@ -32,6 +32,10 @@ class LocationService {
 
   /// Checks and optionally requests location permission.
   /// Only requests permission if not already asked in this session.
+  /// Short-circuits when permission is already granted (always/whileInUse) to
+  /// avoid redundant requestPermission() calls that may behave unexpectedly on
+  /// some Android versions. "Only this time" still works: after app restart,
+  /// permission is revoked, so we request again and show the dialog.
   /// Returns true if permission is granted, false otherwise.
   Future<bool> checkLocationPermissionForSession() async {
     final prefs = await SharedPreferences.getInstance();
@@ -40,7 +44,14 @@ class LocationService {
     LocationPermission permission = await Geolocator.checkPermission();
 
     if (!askedInThisSession) {
-      permission = await Geolocator.requestPermission();
+      // Only request when not already granted - avoids redundant system dialog
+      // for "Always allow" users; "Only this time" users get re-prompted after
+      // app restart when permission is revoked
+      if (permission == LocationPermission.denied ||
+          permission == LocationPermission.deniedForever ||
+          permission == LocationPermission.unableToDetermine) {
+        permission = await Geolocator.requestPermission();
+      }
       await prefs.setBool(_locationAskedKey, true);
     }
 

--- a/lib/utils/location_service.dart
+++ b/lib/utils/location_service.dart
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Modular Open Source Identity Platform
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+*/
+
+import 'package:geolocator/geolocator.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Session-based location permission service.
+/// Tracks if permission was requested in the current session so we can
+/// re-prompt on next login when user had chosen "Only this time" previously.
+class LocationService {
+  static final LocationService instance = LocationService._();
+  LocationService._();
+
+  static const String _locationAskedKey = 'location_asked_this_session';
+
+  /// Call on login success. Clears session flag so permission will be
+  /// requested again if user had chosen "Only this time" previously.
+  Future<void> startNewSession() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_locationAskedKey);
+  }
+
+  /// Call on logout. Clears session flag for next login.
+  Future<void> endSession() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_locationAskedKey);
+  }
+
+  /// Checks and optionally requests location permission.
+  /// Only requests permission if not already asked in this session.
+  /// Returns true if permission is granted, false otherwise.
+  Future<bool> checkLocationPermissionForSession() async {
+    final prefs = await SharedPreferences.getInstance();
+    bool askedInThisSession = prefs.getBool(_locationAskedKey) ?? false;
+
+    LocationPermission permission = await Geolocator.checkPermission();
+
+    if (!askedInThisSession) {
+      permission = await Geolocator.requestPermission();
+      await prefs.setBool(_locationAskedKey, true);
+    }
+
+    if (permission == LocationPermission.denied ||
+        permission == LocationPermission.deniedForever) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/lib/utils/location_service.dart
+++ b/lib/utils/location_service.dart
@@ -70,6 +70,13 @@ class LocationService {
       return false;
     }
 
-    return true;
+    // Only return true for explicitly granted permissions
+    if (permission == LocationPermission.always ||
+        permission == LocationPermission.whileInUse) {
+      return true;
+    }
+
+    // Covers unableToDetermine or any unexpected value
+    return false;
   }
 }

--- a/lib/utils/location_service.dart
+++ b/lib/utils/location_service.dart
@@ -46,17 +46,27 @@ class LocationService {
     if (!askedInThisSession) {
       // Only request when not already granted - avoids redundant system dialog
       // for "Always allow" users; "Only this time" users get re-prompted after
-      // app restart when permission is revoked
       if (permission == LocationPermission.denied ||
-          permission == LocationPermission.deniedForever ||
           permission == LocationPermission.unableToDetermine) {
         permission = await Geolocator.requestPermission();
+        
+        // If user just denied permanently (e.g., clicked "Don't ask again"),
+        // user can manually go to settings to change permission
+        if (permission == LocationPermission.deniedForever) {
+          await prefs.setBool(_locationAskedKey, true);
+          return false;
+        }
       }
       await prefs.setBool(_locationAskedKey, true);
     }
 
-    if (permission == LocationPermission.denied ||
-        permission == LocationPermission.deniedForever) {
+    // If permanently denied (from previous session), return false without
+    // opening settings automatically - let the UI handle it if needed
+    if (permission == LocationPermission.deniedForever) {
+      return false;
+    }
+
+    if (permission == LocationPermission.denied) {
       return false;
     }
 


### PR DESCRIPTION
[RCF-1371]

[RCF-1371]: https://mosip.atlassian.net/browse/RCF-1371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-aware location permission flow to avoid repeated prompts during a session.
  * Location session lifecycle: sessions start at login and end at logout so permissions reset for next sign-in.
  * GPS status check added before location retrieval to improve accuracy indicators.

* **Bug Fixes**
  * Safer navigation after async work—navigation now guards against unmounted contexts to prevent crashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->