### PR TITLE
RCF-1284 hiding next button in bimetric exception screen

### DIFF
--- a/lib/ui/process_ui/widgets_mobile/biometric_capture_scan_block_portrait.dart
+++ b/lib/ui/process_ui/widgets_mobile/biometric_capture_scan_block_portrait.dart
@@ -2977,8 +2977,9 @@ class _BiometricCaptureScanBlockPortraitState
             mainAxisAlignment: MainAxisAlignment.start,
             children: [
               const Spacer(),
-              // Don't show next button when on Mark Exception tab (tab index 2)
-              if (context.read<BiometricCaptureControlProvider>().biometricCaptureScanBlockTabIndex != 2)
+              // Don't show next button when on Mark Exception tab or Exception step
+              if (context.read<BiometricCaptureControlProvider>().biometricCaptureScanBlockTabIndex != 2 &&
+                  context.read<BiometricCaptureControlProvider>().biometricAttribute != "Exception")
                 ElevatedButton(
                   style: ButtonStyle(
                     maximumSize:

--- a/lib/ui/process_ui/widgets_mobile/biometric_capture_scan_block_portrait.dart
+++ b/lib/ui/process_ui/widgets_mobile/biometric_capture_scan_block_portrait.dart
@@ -2977,26 +2977,28 @@ class _BiometricCaptureScanBlockPortraitState
             mainAxisAlignment: MainAxisAlignment.start,
             children: [
               const Spacer(),
-              ElevatedButton(
-                style: ButtonStyle(
-                  maximumSize:
-                  MaterialStateProperty.all<Size>(const Size(200, 68)),
-                  minimumSize:
-                  MaterialStateProperty.all<Size>(const Size(200, 68)),
-                ),
-                onPressed: canProceedToNext()
-                    ? () {
-                        List<String> bioAttributes = (widget
-                                    .field.conditionalBioAttributes!.first!.ageGroup!
-                                    .compareTo(
-                                        context.read<GlobalProvider>().ageGroup) ==
-                                0)
-                            ? _returnBiometricList(
-                                widget.field.conditionalBioAttributes!.first!
-                                    .bioAttributes!,
-                                widget.field.id!)
-                            : _returnBiometricList(
-                                widget.field.bioAttributes!, widget.field.id!);
+              // Don't show next button when on Mark Exception tab (tab index 2)
+              if (context.read<BiometricCaptureControlProvider>().biometricCaptureScanBlockTabIndex != 2)
+                ElevatedButton(
+                  style: ButtonStyle(
+                    maximumSize:
+                    MaterialStateProperty.all<Size>(const Size(200, 68)),
+                    minimumSize:
+                    MaterialStateProperty.all<Size>(const Size(200, 68)),
+                  ),
+                  onPressed: canProceedToNext()
+                      ? () {
+                          List<String> bioAttributes = (widget
+                                      .field.conditionalBioAttributes!.first!.ageGroup!
+                                      .compareTo(
+                                          context.read<GlobalProvider>().ageGroup) ==
+                                  0)
+                              ? _returnBiometricList(
+                                  widget.field.conditionalBioAttributes!.first!
+                                      .bioAttributes!,
+                                  widget.field.id!)
+                              : _returnBiometricList(
+                                  widget.field.bioAttributes!, widget.field.id!);
 
                         var nextElement = _getNextElement(
                             bioAttributes,

--- a/lib/ui/process_ui/widgets_mobile/biometric_capture_scan_block_portrait.dart
+++ b/lib/ui/process_ui/widgets_mobile/biometric_capture_scan_block_portrait.dart
@@ -2978,8 +2978,7 @@ class _BiometricCaptureScanBlockPortraitState
             children: [
               const Spacer(),
               // Don't show next button when on Mark Exception tab or Exception step
-              if (context.read<BiometricCaptureControlProvider>().biometricCaptureScanBlockTabIndex != 2 &&
-                  context.read<BiometricCaptureControlProvider>().biometricAttribute != "Exception")
+              if (context.read<BiometricCaptureControlProvider>().biometricCaptureScanBlockTabIndex != 2)
                 ElevatedButton(
                   style: ButtonStyle(
                     maximumSize:

--- a/lib/ui/process_ui/widgets_mobile/biometric_capture_scan_block_portrait.dart
+++ b/lib/ui/process_ui/widgets_mobile/biometric_capture_scan_block_portrait.dart
@@ -2978,7 +2978,7 @@ class _BiometricCaptureScanBlockPortraitState
             children: [
               const Spacer(),
               // Don't show next button when on Mark Exception tab or Exception step
-              if (context.read<BiometricCaptureControlProvider>().biometricCaptureScanBlockTabIndex != 2)
+              if (context.watch<BiometricCaptureControlProvider>().biometricCaptureScanBlockTabIndex != 2)
                 ElevatedButton(
                   style: ButtonStyle(
                     maximumSize:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The "Next" button in the biometric capture flow is now hidden on the exception-marking screen to prevent accidental advancement; on other screens it behaves as before (including disabled state when progression criteria aren't met). The step progression logic for advancing or exiting the flow has been preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->