### PR TITLE
[RCF-1294] Added allow backup flag config

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         android:icon="@mipmap/launcher_icon"
         android:allowBackup="false"
         android:fullBackupOnly="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:usesCleartextTraffic="false">
        <service android:name=".UploadBackgroundService" />
         <activity

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,8 @@
         android:label="Registration Client"
         android:name="${applicationName}"
         android:icon="@mipmap/launcher_icon"
+        android:allowBackup="false"
+        android:fullBackupOnly="false"
         android:usesCleartextTraffic="false">
        <service android:name=".UploadBackgroundService" />
         <activity
@@ -24,8 +26,6 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:allowBackup="false"
-            android:fullBackupOnly="false"
             android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup disableIfNoEncryptionCapabilities="true">
+        <exclude domain="root" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" path="." />
+    </device-transfer>
+</data-extraction-rules>

--- a/android/clientmanager/src/main/AndroidManifest.xml
+++ b/android/clientmanager/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application
+        android:allowBackup="false"
         android:networkSecurityConfig="@xml/network_security_config">
     </application>
 </manifest>


### PR DESCRIPTION
[RCF-1294]

[RCF-1294]: https://mosip.atlassian.net/browse/RCF-1294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Backup settings standardized to the application level, enforcing disabled backups across the app.
  * Per-screen (activity) backup attributes removed to rely on the centralized configuration.
  * Added data extraction rules to control what can be backed up or transferred from the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->