### PR TITLE
RCF-1303 Added config for capture time out

### DIFF
--- a/android/app/src/main/java/io/mosip/registration_client/api_services/BiometricsDetailsApi.java
+++ b/android/app/src/main/java/io/mosip/registration_client/api_services/BiometricsDetailsApi.java
@@ -695,6 +695,12 @@ public class BiometricsDetailsApi implements BiometricsPigeon.BiometricsApi {
         result.success(response == null ? "" : response);
     }
 
+    @Override
+    public void getCaptureTimeout(@NonNull BiometricsPigeon.Result<Long> result) {
+        int timeout = globalParamRepository.getCachedIntCaptureTimeout();
+        result.success(Long.valueOf(timeout));
+    }
+
     public void handleDeviceInfoResponseForList(Bundle bundle) {
         try {
             byte[] infoBytes = bundle.getByteArray(RegistrationConstants.SBI_INTENT_RESPONSE_KEY);

--- a/android/clientmanager/src/main/java/io/mosip/registration/clientmanager/constant/RegistrationConstants.java
+++ b/android/clientmanager/src/main/java/io/mosip/registration/clientmanager/constant/RegistrationConstants.java
@@ -111,6 +111,7 @@ public class RegistrationConstants {
     public static final String RIGHT_THUMB = "Right Thumb";
     public static final String RIGHT = "Right";
     public static final String LEFT = "Left";
+    public static final String DEFAULT_CAPTURE_TIMEOUT = "10000";
     public static final String PRE_REG_DELETION_CONFIGURED_DAYS = "mosip.registration.pre_reg_deletion_configured_days";
     public static final String REG_DELETION_CONFIGURED_DAYS = "mosip.registration.reg_deletion_configured_days";
     public static final String PRE_REG_DELETE_SUCCESS = "PRE_REG_DELETE_SUCCESS";
@@ -136,6 +137,7 @@ public class RegistrationConstants {
     public static final String HTTP_API_READ_TIMEOUT = "mosip.registration.HTTP_API_READ_TIMEOUT";
     public static final String HTTP_API_WRITE_TIMEOUT = "mosip.registration.HTTP_API_WRITE_TIMEOUT";
     public static final String CAPTURE_TIMEOUT = "mosip.registration.capture_time_out";
+
     public static final String REG_PAK_MAX_TIME_APPRV_LIMIT = "mosip.registration.reg_pak_max_time_apprv_limit";
     public static final String OPT_TO_REG_LAST_EXPORT_REG_PKTS_TIME = "mosip.registration.last_export_registration_config_time";
     public static final String REG_PAK_MAX_CNT_OFFLINE_FREQ = "mosip.registration.packet.maximum.count.offline.frequency";

--- a/android/clientmanager/src/main/java/io/mosip/registration/clientmanager/constant/RegistrationConstants.java
+++ b/android/clientmanager/src/main/java/io/mosip/registration/clientmanager/constant/RegistrationConstants.java
@@ -135,6 +135,7 @@ public class RegistrationConstants {
     public static final String FIELDS_TO_RETAIN_ON_PRID_FETCH = "mosip.registration.fields.to.retain.post.prid.fetch";
     public static final String HTTP_API_READ_TIMEOUT = "mosip.registration.HTTP_API_READ_TIMEOUT";
     public static final String HTTP_API_WRITE_TIMEOUT = "mosip.registration.HTTP_API_WRITE_TIMEOUT";
+    public static final String CAPTURE_TIMEOUT = "mosip.registration.capture_time_out";
     public static final String REG_PAK_MAX_TIME_APPRV_LIMIT = "mosip.registration.reg_pak_max_time_apprv_limit";
     public static final String OPT_TO_REG_LAST_EXPORT_REG_PKTS_TIME = "mosip.registration.last_export_registration_config_time";
     public static final String REG_PAK_MAX_CNT_OFFLINE_FREQ = "mosip.registration.packet.maximum.count.offline.frequency";

--- a/android/clientmanager/src/main/java/io/mosip/registration/clientmanager/repository/GlobalParamRepository.java
+++ b/android/clientmanager/src/main/java/io/mosip/registration/clientmanager/repository/GlobalParamRepository.java
@@ -271,8 +271,12 @@ public class GlobalParamRepository {
         return globalParamMap.get(RegistrationConstants.JOBS_RESTART);
     }
 
-    public int getCachedIntCaptureTimeout(){
-        return getCachedIntegerGlobalParam(RegistrationConstants.CAPTURE_TIMEOUT);
+    public int getCachedIntCaptureTimeout() {
+        long timeout = parseLongWithDefault(RegistrationConstants.CAPTURE_TIMEOUT);
+        if (timeout <= 0L) {
+            return 0;
+        }
+        return timeout > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) timeout;
     }
 
     /**

--- a/android/clientmanager/src/main/java/io/mosip/registration/clientmanager/repository/GlobalParamRepository.java
+++ b/android/clientmanager/src/main/java/io/mosip/registration/clientmanager/repository/GlobalParamRepository.java
@@ -271,6 +271,10 @@ public class GlobalParamRepository {
         return globalParamMap.get(RegistrationConstants.JOBS_RESTART);
     }
 
+    public int getCachedIntCaptureTimeout(){
+        return getCachedIntegerGlobalParam(RegistrationConstants.CAPTURE_TIMEOUT);
+    }
+
     /**
      * Refresh configuration cache by merging global params with local preferences
      */

--- a/android/clientmanager/src/main/java/io/mosip/registration/clientmanager/repository/GlobalParamRepository.java
+++ b/android/clientmanager/src/main/java/io/mosip/registration/clientmanager/repository/GlobalParamRepository.java
@@ -273,10 +273,8 @@ public class GlobalParamRepository {
 
     public int getCachedIntCaptureTimeout() {
         long timeout = parseLongWithDefault(RegistrationConstants.CAPTURE_TIMEOUT);
-        if (timeout <= 0L) {
-            return 0;
-        }
-        return timeout > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) timeout;
+        int defaultTimeout = Integer.parseInt(RegistrationConstants.DEFAULT_CAPTURE_TIMEOUT);
+        return  (timeout <= 0L || timeout > Integer.MAX_VALUE) ? defaultTimeout : (int) timeout;
     }
 
     /**

--- a/android/clientmanager/src/main/java/io/mosip/registration/clientmanager/service/Biometrics095Service.java
+++ b/android/clientmanager/src/main/java/io/mosip/registration/clientmanager/service/Biometrics095Service.java
@@ -93,7 +93,12 @@ public class Biometrics095Service extends BiometricsService {
         CaptureRequest captureRequest = new CaptureRequest();
         captureRequest.setEnv(getServerActiveProfile());
         captureRequest.setPurpose("Registration");
-        captureRequest.setTimeout(10000);
+        int timeout = globalParamRepository.getCachedIntCaptureTimeout();
+        if (timeout <= 0) {
+            timeout = 10000;
+        }
+
+        captureRequest.setTimeout(timeout);
         captureRequest.setSpecVersion("0.9.5");
         List<CaptureBioDetail> list = new ArrayList<>();
         CaptureBioDetail detail = new CaptureBioDetail();

--- a/android/clientmanager/src/main/java/io/mosip/registration/clientmanager/service/Biometrics095Service.java
+++ b/android/clientmanager/src/main/java/io/mosip/registration/clientmanager/service/Biometrics095Service.java
@@ -94,9 +94,6 @@ public class Biometrics095Service extends BiometricsService {
         captureRequest.setEnv(getServerActiveProfile());
         captureRequest.setPurpose("Registration");
         int timeout = globalParamRepository.getCachedIntCaptureTimeout();
-        if (timeout <= 0) {
-            timeout = 10000;
-        }
 
         captureRequest.setTimeout(timeout);
         captureRequest.setSpecVersion("0.9.5");

--- a/lib/platform_android/biometrics_service_impl.dart
+++ b/lib/platform_android/biometrics_service_impl.dart
@@ -195,7 +195,7 @@ class BiometricsServiceImpl implements BiometricsService {
 
   @override
   Future<int> getCaptureTimeout() async {
-    int response = 0;
+    int response = 10000;
     try {
       response = await BiometricsApi().getCaptureTimeout();
     } on PlatformException {

--- a/lib/platform_android/biometrics_service_impl.dart
+++ b/lib/platform_android/biometrics_service_impl.dart
@@ -193,6 +193,19 @@ class BiometricsServiceImpl implements BiometricsService {
     return response;
   }
 
+  @override
+  Future<int> getCaptureTimeout() async {
+    int response = 0;
+    try {
+      response = await BiometricsApi().getCaptureTimeout();
+    } on PlatformException {
+      debugPrint('Get Capture Timeout call failed!');
+    } catch (e) {
+      debugPrint('Fetch Capture Timeout failed: ${e.toString()}');
+    }
+    return response;
+  }
+
 }
 
 BiometricsService getBiometricsServiceImpl() => BiometricsServiceImpl();

--- a/lib/platform_spi/biometrics_service.dart
+++ b/lib/platform_spi/biometrics_service.dart
@@ -41,5 +41,7 @@ abstract class BiometricsService {
 
   Future<String> getOperatorOnboardingBioattributes();
 
+  Future<int> getCaptureTimeout();
+
   factory BiometricsService() => getBiometricsServiceImpl();
 }

--- a/lib/ui/onboard/widgets/operator_biometrics_capture_view.dart
+++ b/lib/ui/onboard/widgets/operator_biometrics_capture_view.dart
@@ -246,9 +246,17 @@ class _OperatorBiometricsCaptureState
                     isSavingBiometrics = true;
                   });
 
+                  // Resolve biometric capture timeout from global params (fallback to 60s)
+                  int timeoutMillis = 10000; // default
+
+                  final timeoutValue = await BiometricsApi().getCaptureTimeout();
+                  if (timeoutValue != null && timeoutValue > 0) {
+                    timeoutMillis = timeoutValue;
+                  }
+
                   String isOperatorBiometricSaved = "";
                   await BiometricsApi().saveOperatorBiometrics().timeout(
-                    const Duration(seconds: 60),
+                    Duration(milliseconds: timeoutMillis),
                     onTimeout: () {
                       return "TIMEOUT";
                     },

--- a/lib/ui/onboard/widgets/operator_biometrics_capture_view.dart
+++ b/lib/ui/onboard/widgets/operator_biometrics_capture_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:provider/provider.dart';
 import 'package:registration_client/model/biometric_attribute_data.dart';
 import 'package:registration_client/pigeon/biometrics_pigeon.dart';
+import 'package:registration_client/platform_spi/biometrics_service.dart';
 import 'package:registration_client/provider/biometric_capture_control_provider.dart';
 import 'package:registration_client/provider/global_provider.dart';
 import 'package:registration_client/provider/registration_task_provider.dart';
@@ -246,9 +247,8 @@ class _OperatorBiometricsCaptureState
                     isSavingBiometrics = true;
                   });
 
-                  // Resolve biometric capture timeout from global params (fallback to 60s)
-
-                  final timeoutMillis = await BiometricsApi().getCaptureTimeout();
+                  // Resolve biometric capture timeout via BiometricsService (fallback handled in service)
+                  final timeoutMillis = await BiometricsService().getCaptureTimeout();
 
                   String isOperatorBiometricSaved = "";
                   await BiometricsApi().saveOperatorBiometrics().timeout(

--- a/lib/ui/onboard/widgets/operator_biometrics_capture_view.dart
+++ b/lib/ui/onboard/widgets/operator_biometrics_capture_view.dart
@@ -247,12 +247,8 @@ class _OperatorBiometricsCaptureState
                   });
 
                   // Resolve biometric capture timeout from global params (fallback to 60s)
-                  int timeoutMillis = 10000; // default
 
-                  final timeoutValue = await BiometricsApi().getCaptureTimeout();
-                  if (timeoutValue != null && timeoutValue > 0) {
-                    timeoutMillis = timeoutValue;
-                  }
+                  final timeoutMillis = await BiometricsApi().getCaptureTimeout();
 
                   String isOperatorBiometricSaved = "";
                   await BiometricsApi().saveOperatorBiometrics().timeout(

--- a/pigeon/biometrics.dart
+++ b/pigeon/biometrics.dart
@@ -66,4 +66,7 @@ abstract class BiometricsApi {
 
   @async
   String getOperatorOnboardingBioattributes();
+
+  @async
+  int getCaptureTimeout();
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Biometric capture timeout is now configurable and retrieved dynamically at runtime.
  * The app exposes a service API to obtain the configured capture timeout for platform integrations.

* **Behavior**
  * Operator biometric capture uses the configured timeout (when valid) instead of a fixed 60-second limit.
  * If the configured timeout is invalid or unavailable, the app falls back to the previous default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->