### PR TITLE
Fix audit Pigeon callback completion

### DIFF
--- a/android/app/src/main/java/io/mosip/registration_client/api_services/AuditDetailsApi.java
+++ b/android/app/src/main/java/io/mosip/registration_client/api_services/AuditDetailsApi.java
@@ -42,9 +42,13 @@ public class AuditDetailsApi implements AuditResponsePigeon.AuditResponseApi {
                     .orElse(null);
             if (matchedEvent != null) {
                 auditEvent(matchedEvent, componentId, arguments);
+            } else {
+                Log.w(getClass().getSimpleName(), "Unknown audit event id/name: " + id);
             }
         } catch (Exception e) {
             Log.e(getClass().getSimpleName(), "Exception in system audit event!", e);
+        } finally {
+            result.success(null);
         }
     }
 


### PR DESCRIPTION
## Summary
Ensured the audit Pigeon call always completes by returning [result.success(null)] in a finally block and logging unknown audit IDs so await calls never hang. This change is isolated to the Android host implementation where the callback is owned: [AuditDetailsApi.java:36-52]
Fixes made-
- Always complete the Audit Pigeon callback to prevent await hangs
- Log unknown audit event IDs for easier diagnostics
