### PR TITLE
RCF-888: Add not uploaded server status filter

### DIFF
--- a/assets/l10n/app_ar.arb
+++ b/assets/l10n/app_ar.arb
@@ -174,6 +174,7 @@
   },
   "client_status": "  حالة العميل",
   "server_status": "حالة الملقم",
+  "not_uploaded": "غير مرفوع",
   "review_status": "حالة المراجعة",
   "clear_filter": "مرشح واضح",
   "serial_number": "س.ن",

--- a/assets/l10n/app_en.arb
+++ b/assets/l10n/app_en.arb
@@ -174,6 +174,7 @@
   },
   "client_status": "Client Status",
   "server_status": "Server Status",
+  "not_uploaded": "NOT UPLOADED",
   "review_status": "Review Status",
   "clear_filter": "Clear Filter",
   "serial_number": "Sl.no",

--- a/assets/l10n/app_fr.arb
+++ b/assets/l10n/app_fr.arb
@@ -174,6 +174,7 @@
   },
   "client_status": "Statut du client",
   "server_status": "État du serveur",
+  "not_uploaded": "NON TÉLÉVERSÉ",
   "clear_filter": "Effacer le filtre",
   "review_status": "Statut d'examen",
   "serial_number": "S.non",

--- a/assets/l10n/app_hi.arb
+++ b/assets/l10n/app_hi.arb
@@ -174,6 +174,7 @@
   },
   "client_status": "ग्राहक स्थिति",
   "server_status": "सर्वर की स्थिति",
+  "not_uploaded": "अपलोड नहीं किया गया",
   "clear_filter": "फ़िल्टर साफ़ करें",
   "review_status": "समीक्षा स्थिति",
   "serial_number": "क्र.सं",

--- a/assets/l10n/app_kn.arb
+++ b/assets/l10n/app_kn.arb
@@ -174,6 +174,7 @@
   },
   "client_status": "ಕ್ಲೈಂಟ್ ಸ್ಥಿತಿ",
   "server_status": "ಸರ್ವರ್ ಸ್ಥಿತಿ",
+  "not_uploaded": "ಅಪ್ಲೋಡ್ ಆಗಿಲ್ಲ",
   "clear_filter": "Clear Filter",
   "review_status": "ಪುನರ್ ಪರಿಶೀಲನೆ ಸ್ಥಿತಿ",
   "serial_number": "ಎಸ್.ಎನ್",

--- a/assets/l10n/app_ta.arb
+++ b/assets/l10n/app_ta.arb
@@ -166,6 +166,7 @@
   },
   "client_status": "வாடிக்கையாளர் நிலை",
   "server_status": "சேவையக நிலை",
+  "not_uploaded": "பதிவேற்றப்படவில்லை",
   "review_status": "மீளாய்வு நிலை",
   "clear_filter": "Clear Filter",
   "serial_number": "எஸ்.என்",

--- a/lib/provider/export_packet_provider.dart
+++ b/lib/provider/export_packet_provider.dart
@@ -11,6 +11,8 @@ import 'package:registration_client/utils/constants.dart';
 import '../platform_spi/packet_service.dart';
 
 class ExportPacketsProvider with ChangeNotifier {
+  static const String notUploadedServerStatusFilter = "__not_uploaded__";
+
   List<Registration> packetsList = [];
 
   List<Registration> matchingPackets = [];
@@ -87,15 +89,7 @@ class ExportPacketsProvider with ChangeNotifier {
     matchingPackets.clear();
     for (int i = 0; i < packetsList.length; i++) {
       matchingSelected[i] = false;
-      if (packetsList[i].packetId.contains(searchList)) {
-        if (clientStatus != null &&
-            clientStatus != packetsList[i].clientStatus) {
-          continue;
-        }
-        if (serverStatus != null &&
-            serverStatus != packetsList[i].serverStatus) {
-          continue;
-        }
+      if (_matchesFilters(packetsList[i])) {
         matchingPackets.add(packetsList[i]);
       }
     }
@@ -107,20 +101,28 @@ class ExportPacketsProvider with ChangeNotifier {
     matchingPackets.clear();
     for (int i = 0; i < packetsList.length; i++) {
       matchingSelected[i] = false;
-      if (packetsList[i].packetId.contains(searchList)) {
-        if (clientStatus != null &&
-            clientStatus != packetsList[i].clientStatus) {
-          continue;
-        }
-        if (serverStatus != null &&
-            serverStatus != packetsList[i].serverStatus) {
-          continue;
-        }
+      if (_matchesFilters(packetsList[i])) {
         matchingPackets.add(packetsList[i]);
       }
     }
     countSelected = 0;
     notifyListeners();
+  }
+
+  bool _matchesFilters(Registration packet) {
+    if (!packet.packetId.contains(searchList)) {
+      return false;
+    }
+    if (clientStatus != null && clientStatus != packet.clientStatus) {
+      return false;
+    }
+    if (serverStatus == notUploadedServerStatusFilter) {
+      return packet.serverStatus == null || packet.serverStatus!.trim().isEmpty;
+    }
+    if (serverStatus != null && serverStatus != packet.serverStatus) {
+      return false;
+    }
+    return true;
   }
 
   Future<void> uploadSelected() async {

--- a/lib/ui/export_packet/widgets/server_status_dropdown.dart
+++ b/lib/ui/export_packet/widgets/server_status_dropdown.dart
@@ -25,9 +25,9 @@ class ServerStatusDropdown extends StatelessWidget {
         padding: const EdgeInsets.all(16),
         items:   [
           DropdownMenuItem(value: null, child: Text(AppLocalizations.of(context)!.server_status)),
-          const DropdownMenuItem(
+          DropdownMenuItem(
               value: ExportPacketsProvider.notUploadedServerStatusFilter,
-              child: Text("NOT UPLOADED")),
+              child: Text(AppLocalizations.of(context)!.not_uploaded)),
           const DropdownMenuItem(value: "Packet has reached Packet Receiver", child: Text("Received")),
           const DropdownMenuItem(value: "Processing", child: Text("Processing")),
           const DropdownMenuItem(value: "Accepted", child: Text("Accepted")),

--- a/lib/ui/export_packet/widgets/server_status_dropdown.dart
+++ b/lib/ui/export_packet/widgets/server_status_dropdown.dart
@@ -25,6 +25,9 @@ class ServerStatusDropdown extends StatelessWidget {
         padding: const EdgeInsets.all(16),
         items:   [
           DropdownMenuItem(value: null, child: Text(AppLocalizations.of(context)!.server_status)),
+          const DropdownMenuItem(
+              value: ExportPacketsProvider.notUploadedServerStatusFilter,
+              child: Text("NOT UPLOADED")),
           const DropdownMenuItem(value: "Packet has reached Packet Receiver", child: Text("Received")),
           const DropdownMenuItem(value: "Processing", child: Text("Processing")),
           const DropdownMenuItem(value: "Accepted", child: Text("Accepted")),


### PR DESCRIPTION
[RCF-888]

Fixes #925

## Summary
- Added a `NOT UPLOADED` option to the Manage Applications server status filter.
- Treat empty or missing packet server status as not uploaded, matching the existing table display.
- Reused the same filter matching logic for search and dropdown filtering.

## Validation
- `git diff --check`

Flutter/Dart tooling was not available in the local shell, so formatter/analyzer checks could not be run locally.

[RCF-888]: https://mosip.atlassian.net/browse/RCF-888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Not Uploaded" server-status filter so users can easily find packets that haven’t been uploaded.

* **Improvements**
  * Filtering logic refined so the "Not Uploaded" selection reliably matches packets with no/blank server status.

* **Localization**
  * Added translations for the "Not Uploaded" label (English, Arabic, French, Hindi, Kannada, Tamil).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->