### PR TITLE
fix: replace global GestureDetector with Listener to resolve touch in…

### DIFF
--- a/lib/utils/inactivity_tracker.dart
+++ b/lib/utils/inactivity_tracker.dart
@@ -180,12 +180,21 @@ class _InactivityTrackerState extends State<InactivityTracker> with WidgetsBindi
   }
 
   @override
+  // Widget build(BuildContext context) {
+  //   return GestureDetector(
+  //     behavior: HitTestBehavior.translucent,
+  //     onTap: _onUserInteraction,
+  //     onPanDown: (_) => _onUserInteraction(),
+  //     onScaleStart: (_) => _onUserInteraction(),
+  //     child: widget.child,
+  //   );
+  // }
+  @override
   Widget build(BuildContext context) {
-    return GestureDetector(
+    return Listener(
       behavior: HitTestBehavior.translucent,
-      onTap: _onUserInteraction,
-      onPanDown: (_) => _onUserInteraction(),
-      onScaleStart: (_) => _onUserInteraction(),
+      onPointerDown: (_) => _onUserInteraction(),
+      onPointerMove: (_) => _onUserInteraction(),
       child: widget.child,
     );
   }


### PR DESCRIPTION
## Description
This PR addresses a subtle but impactful UI performance issue caused by the `InactivityTracker`.

Previously, the app was wrapped in a top-level `GestureDetector`. Because `GestureDetector` participates in Flutter's Gesture Arena, it actively competed with child widgets (scroll views, buttons, sliders) for touch events, which can lead to dropped inputs and scroll stuttering.

### Changes Made
* **Replaced `GestureDetector` with `Listener`** in `inactivity_tracker.dart`.
* Updated the interaction callbacks to use raw OS-level pointer events (`onPointerDown`, `onPointerMove`).
* Because `Listener` does not enter the Gesture Arena, the app can now silently track inactivity without interfering with standard UI interactions.

### Related Issue
Closes #1042 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance improvement (improves app responsiveness)

### Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or exceptions.