### PR TITLE
fix: replace non-growable List.empty() with [] literal to prevent Uns…

### DIFF
--- a/lib/platform_android/biometrics_service_impl.dart
+++ b/lib/platform_android/biometrics_service_impl.dart
@@ -169,7 +169,7 @@ class BiometricsServiceImpl implements BiometricsService {
 
   @override
   Future<List<DeviceInfo?>> getListOfDevices(String modality) async {
-    List<DeviceInfo?> deviceList = List.empty();
+    List<DeviceInfo?> deviceList = [];
     try {
       deviceList = await BiometricsApi().getListOfDevices(modality);
     } on PlatformException {

--- a/lib/platform_android/process_spec_service_impl.dart
+++ b/lib/platform_android/process_spec_service_impl.dart
@@ -18,9 +18,9 @@ class ProcessSpecServiceImpl implements ProcessSpecService {
       listOfProcesses = await ProcessSpecApi().getNewProcessSpec();
     } on PlatformException {
       debugPrint("Process Spec Api failed!");
-      listOfProcesses = List.empty();
+      listOfProcesses = [];
     }  catch (e) {
-      listOfProcesses = List.empty();
+      listOfProcesses = [];
       debugPrint("Process spec fetch error: $e");
     }
     
@@ -99,9 +99,9 @@ class ProcessSpecServiceImpl implements ProcessSpecService {
       optionalLanguageCodes = await ProcessSpecApi().getOptionalLanguageCodes();
     } on PlatformException {
       debugPrint("Process Spec Api failed!");
-      optionalLanguageCodes = List.empty();
+      optionalLanguageCodes = [];
     }  catch (e) {
-      optionalLanguageCodes = List.empty();
+      optionalLanguageCodes = [];
       debugPrint("Process spec fetch error: $e");
     }
     return optionalLanguageCodes;
@@ -114,9 +114,9 @@ class ProcessSpecServiceImpl implements ProcessSpecService {
       settingSpec = await ProcessSpecApi().getSettingSpec();
     } on PlatformException {
       debugPrint("Settings Spec Api failed!");
-      settingSpec = List.empty();
+      settingSpec = [];
     } catch (e) {
-      settingSpec = List.empty();
+      settingSpec = [];
       debugPrint("Settings spec fetch error: $e");
     }
     return settingSpec;


### PR DESCRIPTION
## Description
This PR resolves a hidden runtime crash risk caused by the default behavior of Dart's `List.empty()`.

In several service implementations, `List.empty()` was used to initialize lists or as a fallback return value in `catch` blocks. Because `List.empty()` defaults to `growable: false`, any subsequent attempt by the UI or providers to append items (`.add()`) to these fallback lists would result in an immediate `UnsupportedError (Cannot add to a fixed-length list)`.

### Changes Made
* Replaced instances of `List.empty()` with the standard growable list literal `[]` in `biometrics_service_impl.dart` and `process_spec_service_impl.dart`.
* This ensures that fallback lists returned during network or platform failures can be safely interacted with by the UI without throwing exceptions.

### Related Issue
Closes #1049 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Stability improvement (prevents runtime collection errors)

### Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimizations for improved consistency across the codebase. No user-facing changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/android-registration-client/pull/1050)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->