### PR TITLE
fix: replace push with pushReplacement in login navigation to prevent…

### DIFF
--- a/lib/ui/login_page.dart
+++ b/lib/ui/login_page.dart
@@ -378,7 +378,7 @@ class _LoginPageState extends State<LoginPage> with WidgetsBindingObserver {
       }
 
       if (!context.mounted) return;
-      Navigator.of(context).push(
+      Navigator.of(context).pushReplacement(
         MaterialPageRoute(
           builder: (context) => Responsive(
             mobile: DashBoardTabletView(),


### PR DESCRIPTION
## Description
This PR resolves a critical navigation lifecycle bug where the `LoginPage` was left in the active routing stack after a successful authentication.

Previously, `_navigateToHomePage()` utilized `Navigator.of(context).push()`. This allowed authenticated users to press the hardware back button from the Dashboard and inadvertently return to the Login screen, resulting in a broken User Experience and improper session flow. 

### Changes Made
* Updated the navigation method in `login_page.dart` from `.push()` to `.pushReplacement()`.
* This ensures that the authentication UI is destroyed and removed from the stack once the user successfully reaches the `DashBoardTabletView`.

### Related Issue
Closes #1056 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] UX improvement (Fixes broken hardware back-button behavior)

### Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation behavior after login to prevent users from returning to the login page via the back button.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/android-registration-client/pull/1057)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->