### PR TITLE
fix: resolve silent document upload failures on Android 13+ by implem…

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
 
     <!-- Storage - older Android -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29"/>
     <!-- Storage - Android 13+ -->
     <!-- Full storage access for documents/PDFs (all Android versions) -->

--- a/lib/ui/process_ui/widgets/document_upload_control.dart
+++ b/lib/ui/process_ui/widgets/document_upload_control.dart
@@ -7,6 +7,8 @@
 
 import 'dart:io';
 
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -560,6 +562,31 @@ class _DocumentUploadControlState extends State<DocumentUploadControl> {
                                     ? null
                                     : () async {
                                   _documentScanClickedAudit();
+                                  bool isGranted = false;
+                                  if (Platform.isAndroid) {
+                                    final androidInfo = await DeviceInfoPlugin().androidInfo;
+                                    if (androidInfo.version.sdkInt >= 33) {
+                                      // Android 13+: Granular media permission
+                                      final photosStatus = await Permission.photos.request();
+                                      isGranted = photosStatus.isGranted;
+                                    } else {
+                                      // Android 12 and below: Legacy storage permission
+                                      final storageStatus = await Permission.storage.request();
+                                      isGranted = storageStatus.isGranted;
+                                    }
+                                  } else {
+                                    final storageStatus = await Permission.storage.request();
+                                    isGranted = storageStatus.isGranted;
+                                  }
+                                  if (!isGranted) {
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      const SnackBar(
+                                        content: Text('Storage permission is required to select documents.'),
+                                        backgroundColor: Colors.red,
+                                      ),
+                                    );
+                                    return;
+                                  }
                                   var doc = await Navigator.push(
                                     context,
                                     MaterialPageRoute(
@@ -567,7 +594,6 @@ class _DocumentUploadControlState extends State<DocumentUploadControl> {
                                             CustomScanner(
                                                 field: widget.field)),
                                   );
-
                                   await addDocument(
                                       doc, widget.field, referenceNumber);
                                   await getScannedDocuments(widget.field);
@@ -828,20 +854,45 @@ class _DocumentUploadControlState extends State<DocumentUploadControl> {
                                 minimumSize: Size(100.w, 48.h),
                               ),
                               onPressed: (documentController.text == "")
-                                  ? null
-                                  : () async {
-                                _documentScanClickedAudit();
-                                var doc = await Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                      builder: (context) => CustomScanner(
-                                          field: widget.field)),
-                                );
-                                await addDocument(
-                                    doc, widget.field, referenceNumber);
-
-                                await getScannedDocuments(widget.field);
-                              },
+                                    ? null
+                                    : () async {
+                                  _documentScanClickedAudit();
+                                  bool isGranted = false;
+                                  if (Platform.isAndroid) {
+                                    final androidInfo = await DeviceInfoPlugin().androidInfo;
+                                    if (androidInfo.version.sdkInt >= 33) {
+                                      // Android 13+: Granular media permission
+                                      final photosStatus = await Permission.photos.request();
+                                      isGranted = photosStatus.isGranted;
+                                    } else {
+                                      // Android 12 and below: Legacy storage permission
+                                      final storageStatus = await Permission.storage.request();
+                                      isGranted = storageStatus.isGranted;
+                                    }
+                                  } else {
+                                    final storageStatus = await Permission.storage.request();
+                                    isGranted = storageStatus.isGranted;
+                                  }
+                                  if (!isGranted) {
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      const SnackBar(
+                                        content: Text('Storage permission is required to select documents.'),
+                                        backgroundColor: Colors.red,
+                                      ),
+                                    );
+                                    return;
+                                  }
+                                  var doc = await Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                        builder: (context) =>
+                                            CustomScanner(
+                                                field: widget.field)),
+                                  );
+                                  await addDocument(
+                                      doc, widget.field, referenceNumber);
+                                  await getScannedDocuments(widget.field);
+                                },
                               child: Row(
                                 mainAxisAlignment: MainAxisAlignment.center,
                                 children: [


### PR DESCRIPTION
## Description
This PR resolves a critical device-fragmentation bug where the document upload feature silently failed on modern Android tablets (Android 13 / API 33+).

Previously, the application exclusively requested `Permission.storage` (`READ_EXTERNAL_STORAGE`) before opening the file picker. On Android 13+, this legacy permission is completely deprecated and is silently denied by the OS without prompting the user, entirely blocking the document registration workflow.

### Changes Made
* **AndroidManifest.xml:** Added granular media permissions (`READ_MEDIA_IMAGES` and `READ_MEDIA_VIDEO`) to support modern Android API levels.
* **document_upload_control.dart:** Implemented `device_info_plus` to conditionally check the Android SDK version at runtime. The app now correctly requests `Permission.photos` for Android 13+ devices, while maintaining legacy `Permission.storage` support for older devices.

### Related Issue
Closes #1058 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Device Compatibility (Android 13+ SDK support)

### Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated storage and media permissions to comply with Android 13+ requirements. The app now requests appropriate photo or storage permissions when accessing media files, ensuring compatibility with newer Android versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/android-registration-client/pull/1059)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->