### PR TITLE
fix: resolve severe memory leak by disposing controllers in DocumentU…

### DIFF
--- a/lib/ui/process_ui/widgets/document_upload_control.dart
+++ b/lib/ui/process_ui/widgets/document_upload_control.dart
@@ -154,6 +154,13 @@ class _DocumentUploadControlState extends State<DocumentUploadControl> {
     _getListOfReferenceNumber();
   }
 
+  @override
+  void dispose() {
+    documentController.dispose();
+    scrollController.dispose();
+    super.dispose();
+  }
+
   _getPreRegData(Field e) {
     Map<String?, Object?> value = registrationTaskProvider.preRegistrationData;
     if (value.isNotEmpty) {


### PR DESCRIPTION
## Description
This PR resolves a critical memory leak within the document upload workflow that could lead to Out-of-Memory (OOM) application crashes during long operator sessions.

Previously, `_DocumentUploadControlState` instantiated a `TextEditingController` and a `FixedExtentScrollController` but failed to implement a `dispose()` method. This caused "ghost" controllers to remain active in memory every time the widget was destroyed, compounding RAM usage over multiple registrations until the OS killed the process.

### Changes Made
* Implemented the `@override void dispose()` lifecycle method in `document_upload_control.dart`.
* Explicitly invoked `.dispose()` on `documentController` and `scrollController` to release native memory bindings.

### Related Issue
Closes #1061 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance/Stability improvement (Prevents RAM exhaustion)

### Checklist
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource management in document upload control to prevent potential memory leaks during widget disposal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/android-registration-client/pull/1062)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->