### PR TITLE
Add use-pr-linker workflow to auto-link PRs to issues

### DIFF
--- a/.github/workflows/use-pr-linker.yml
+++ b/.github/workflows/use-pr-linker.yml
@@ -1,0 +1,21 @@
+name: Auto link PR to Issues
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - closed
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  call-linker:
+    uses: mosip/kattu/.github/workflows/link-pr-to-issue.yml@develop
+    secrets:
+      ACTION_PAT: ${{ secrets.ACTION_PAT }}


### PR DESCRIPTION
## Summary
Adds `use-pr-linker.yml` workflow that calls the reusable PR-to-issue linker from `mosip/kattu` (`@develop`).

## Notes
- Requires `ACTION_PAT` repository secret to be configured.
- Target branch: `release-0.12.x`.